### PR TITLE
Prevent sql injection in redeem command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Simplistic wude im Rahmen der Projekttage der TBS1 entwickelt. Simplistic besteh
   + Bearbeitete hauptsächlich die Simplistic-App (siehe anderes Repo).
 
 + Kevin D.
-  + Bearbeitete genauso wie Justing die App (siehe anderes Repo).
+  + Bearbeitete genauso wie Justin die App (siehe anderes Repo).
 
 ## Alle verfügbaren Module
 |Modul   |Beschreibung   |

--- a/cogs/noRelease-codes.py
+++ b/cogs/noRelease-codes.py
@@ -35,7 +35,9 @@ class Cases(commands.Cog):
 
     @commands.command()
     async def redeem(self, ctx, code):
-        db.database.execute(f"SELECT * FROM codes WHERE code = '{code}'")
+        db.database.execute(f"SELECT * FROM codes WHERE code = %(code)s", {
+            "code": code
+        })
         result = db.database.fetchall()
         if len(result) == 0:
             await ctx.send("Dieser Code existiert nicht.")

--- a/config/config.ini
+++ b/config/config.ini
@@ -5,4 +5,4 @@ pass=adminSimplistic
 db=bot_db
 
 [Bot]
-token=ODgyMjI5ODIzNDcxMjIyODQ0.YS4WjA.4kSTo2dD4Rfh_mdmdWRtLd4TxkE
+token=


### PR DESCRIPTION
Since the `code`-parameter is directly inputted into a sql statement, it is susceptible for sql injections. The python module helps you if you are using parameters as seen in the commit. :)